### PR TITLE
Embed ClickUp docs for resource pages

### DIFF
--- a/components/components/homepageContent/LabSlip.js
+++ b/components/components/homepageContent/LabSlip.js
@@ -1,113 +1,21 @@
-import * as React from "react";
-import { Button } from "@mui/material";
-import dynamic from "next/dynamic";
-
-const Document = dynamic(() => import("react-pdf").then((m) => m.Document), { ssr: false });
-const Page = dynamic(() => import("react-pdf").then((m) => m.Page), { ssr: false });
-const getPdfjs = async () => (await import("react-pdf")).pdfjs;
-
-const pdfs = [
-  {
-    id: 1,
-    title: "Dummy 1",
-    url: "/pdfs/PDF-3.pdf",
-  },{
-    id: 2,
-    title: "Dummy 2",
-    url: "/pdfs/dummy.pdf",
-  },{
-    id: 3,
-    title: "Dummy 3",
-    url: "/pdfs/dummy.pdf",
-  },
-];
-
-const PDFViewer = ({ file, title }) => {
-  const [numPages, setNumPages] = React.useState(null);
-  const [pageNumber, setPageNumber] = React.useState(1);
-  const [isReady, setIsReady] = React.useState(false);
-  const containerRef = React.useRef(null);
-  const [pageWidth, setPageWidth] = React.useState(undefined);
-
-  React.useEffect(() => {
-    let mounted = true;
-    (async () => {
-      const pdfjs = await getPdfjs();
-      const workerPathESM = "/pdf.worker.min.mjs";
-      const workerPathIIFE = "/pdf.worker.min.js";
-      try {
-        pdfjs.GlobalWorkerOptions.workerSrc = workerPathESM;
-      } catch (e) {
-        pdfjs.GlobalWorkerOptions.workerSrc = workerPathIIFE;
-      }
-      if (mounted) setIsReady(true);
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (!containerRef.current) return;
-    const element = containerRef.current;
-    const update = () => {
-      const width = element.clientWidth;
-      setPageWidth(width > 0 ? width : undefined);
-    };
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(element);
-    return () => ro.disconnect();
-  }, [isReady]);
-
-  const onDocumentLoadSuccess = ({ numPages }) => {
-    setNumPages(numPages);
-    setPageNumber(1);
-  };
-
-  const prevPage = () => setPageNumber((p) => Math.max(p - 1, 1));
-  const nextPage = () => setPageNumber((p) => Math.min(p + 1, numPages || 1));
-
-  if (!isReady) {
-    return <div style={{ width: "60%" }}>Loading PDF…</div>;
-  }
-
-  return (
-    <div style={{ width: "60%" }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-        <h3 style={{ margin: 0, fontWeight: 600 }}>{title}</h3>
-        <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-          <Button variant="outlined" onClick={prevPage} disabled={pageNumber <= 1}>
-            Prev
-          </Button>
-          <Button variant="outlined" onClick={nextPage} disabled={!numPages || pageNumber >= numPages}>
-            Next
-          </Button>
-        </div>
-      </div>
-      <div ref={containerRef} style={{ border: "1px solid #eee", borderRadius: 8, padding: 12, background: "#fafafa", display: "flex", justifyContent: "center", alignItems: "center" }}>
-        <Document file={file} onLoadSuccess={onDocumentLoadSuccess} loading={<div>Loading PDF…</div>} >
-          <Page pageNumber={pageNumber} width={pageWidth} renderTextLayer={false} renderAnnotationLayer={false} />
-        </Document>
-      </div>
-      <div style={{ marginTop: 8, color: "#666" }}>
-        Page {pageNumber}{numPages ? ` / ${numPages}` : ""}
-      </div>
-    </div>
-  );
-};
+import Script from "next/script";
 
 const LabSlip = () => {
   return (
     <div style={{ padding: "20px" }}>
       <h2 className="mb-1" style={{ color: "#ef5350", fontWeight: 600 }}>
-        Lab Slip
+        Quick Start
       </h2>
-      <div style={{ width: "100%", display: "flex", gap: "10px", flexDirection: "column" }}>
-        {pdfs.map((item) => (
-          <PDFViewer key={item.id} file={item.url} title={item.title} />
-        ))}
+      <div style={{ width: "100%", height: "80vh" }}>
+        <iframe
+          className="clickup-embed clickup-dynamic-height"
+          src="https://doc.clickup.com/8469349/d/h/82ev5-21111/34c3e96a27da043"
+          width="100%"
+          height="100%"
+          style={{ background: "transparent", border: "1px solid #ccc" }}
+        />
       </div>
+      <Script async src="https://app-cdn.clickup.com/assets/js/forms-embed/v1.js" />
     </div>
   );
 };

--- a/components/components/homepageContent/Policies.js
+++ b/components/components/homepageContent/Policies.js
@@ -1,23 +1,4 @@
-import * as React from "react";
-import { Button } from "@mui/material";
-
-const pdfs = [
-  {
-    id: 1,
-    title: "Dummy 1",
-    url: "/pdfs/dummy.pdf",
-  },
-  {
-    id: 2,
-    title: "Dummy 2",
-    url: "/pdfs/dummy.pdf",
-  },
-  {
-    id: 2,
-    title: "Dummy 3",
-    url: "/pdfs/dummy.pdf",
-  },
-];
+import Script from "next/script";
 
 const Policies = () => {
   return (
@@ -25,26 +6,16 @@ const Policies = () => {
       <h2 className="mb-1" style={{ color: "#ef5350", fontWeight: 600 }}>
         Policies
       </h2>
-      <div style={{ width: "100%", display: "flex", gap: "10px" }}>
-        {pdfs.map((item) => (
-          <a href={item.url} download={`${item.title}.pdf`} key={item.id}>
-            {" "}
-            <Button
-              variant="contained"
-              color="error"
-              size="large"
-              sx={{
-                py: 1.5,
-                px: 6,
-                minWidth: "240px",
-                textTransform: "uppercase",
-              }}
-            >
-              Download {item.title}
-            </Button>
-          </a>
-        ))}
+      <div style={{ width: "100%", height: "80vh" }}>
+        <iframe
+          className="clickup-embed clickup-dynamic-height"
+          src="https://doc.clickup.com/8469349/d/h/82ev5-21051/92ef4f301194498"
+          width="100%"
+          height="100%"
+          style={{ background: "transparent", border: "1px solid #ccc" }}
+        />
       </div>
+      <Script async src="https://app-cdn.clickup.com/assets/js/forms-embed/v1.js" />
     </div>
   );
 };

--- a/components/components/homepageContent/SalesMaterial.js
+++ b/components/components/homepageContent/SalesMaterial.js
@@ -1,23 +1,4 @@
-import * as React from "react";
-import { Button } from "@mui/material";
-
-const pdfs = [
-  {
-    id: 1,
-    title: "Dummy 1",
-    url: "/pdfs/dummy.pdf",
-  },
-  {
-    id: 2,
-    title: "Dummy 2",
-    url: "/pdfs/dummy.pdf",
-  },
-  {
-    id: 2,
-    title: "Dummy 3",
-    url: "/pdfs/dummy.pdf",
-  },
-];
+import Script from "next/script";
 
 const SalesMaterial = () => {
   return (
@@ -25,26 +6,16 @@ const SalesMaterial = () => {
       <h2 className="mb-1" style={{ color: "#ef5350", fontWeight: 600 }}>
         Sales Material
       </h2>
-      <div style={{ width: "100%", display: "flex", gap: "10px" }}>
-        {pdfs.map((item) => (
-          <a href={item.url} download={`${item.title}.pdf`} key={item.id}>
-            {" "}
-            <Button
-              variant="contained"
-              color="error"
-              size="large"
-              sx={{
-                py: 1.5,
-                px: 6,
-                minWidth: "240px",
-                textTransform: "uppercase",
-              }}
-            >
-              Download {item.title}
-            </Button>
-          </a>
-        ))}
+      <div style={{ width: "100%", height: "80vh" }}>
+        <iframe
+          className="clickup-embed clickup-dynamic-height"
+          src="https://doc.clickup.com/8469349/d/h/82ev5-21091/81719dc5c6aaf00"
+          width="100%"
+          height="100%"
+          style={{ background: "transparent", border: "1px solid #ccc" }}
+        />
       </div>
+      <Script async src="https://app-cdn.clickup.com/assets/js/forms-embed/v1.js" />
     </div>
   );
 };

--- a/components/components/homepageContent/StaffTraining.js
+++ b/components/components/homepageContent/StaffTraining.js
@@ -1,129 +1,4 @@
-import * as React from "react";
-import { Button } from "@mui/material";
-import dynamic from "next/dynamic";
-
-const Document = dynamic(() => import("react-pdf").then((m) => m.Document), {
-  ssr: false,
-});
-const Page = dynamic(() => import("react-pdf").then((m) => m.Page), {
-  ssr: false,
-});
-const getPdfjs = async () => (await import("react-pdf")).pdfjs;
-
-const pdfs = [
-  {
-    id: 1,
-    title: "Staff Training Guide",
-    url: "/pdfs/staff-training-1.pdf",
-  },
-  {
-    id: 2,
-    title: "Staff Training Checklist",
-    url: "/pdfs/staff-training-2.pdf",
-  },
-];
-
-const PDFViewer = ({ file, title }) => {
-  const [numPages, setNumPages] = React.useState(null);
-  const [pageNumber, setPageNumber] = React.useState(1);
-  const [isReady, setIsReady] = React.useState(false);
-  const containerRef = React.useRef(null);
-  const [pageWidth, setPageWidth] = React.useState(undefined);
-
-  React.useEffect(() => {
-    let mounted = true;
-    (async () => {
-      const pdfjs = await getPdfjs();
-      const workerPathESM = "/pdf.worker.min.mjs";
-      const workerPathIIFE = "/pdf.worker.min.js";
-      try {
-        pdfjs.GlobalWorkerOptions.workerSrc = workerPathESM;
-      } catch (e) {
-        pdfjs.GlobalWorkerOptions.workerSrc = workerPathIIFE;
-      }
-      if (mounted) setIsReady(true);
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (!containerRef.current) return;
-    const element = containerRef.current;
-    const update = () => {
-      const width = element.clientWidth;
-      setPageWidth(width > 0 ? width : undefined);
-    };
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(element);
-    return () => ro.disconnect();
-  }, [isReady]);
-
-  const onDocumentLoadSuccess = ({ numPages }) => {
-    setNumPages(numPages);
-    setPageNumber(1);
-  };
-
-  const prevPage = () => setPageNumber((p) => Math.max(p - 1, 1));
-  const nextPage = () => setPageNumber((p) => Math.min(p + 1, numPages || 1));
-
-  if (!isReady) {
-    return <div style={{ width: "60%" }}>Loading PDF…</div>;
-  }
-
-  return (
-    <div style={{ width: "60%" }}>
-      <div
-        style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}
-      >
-        <h3 style={{ margin: 0, fontWeight: 600 }}>{title}</h3>
-        <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-          <Button variant="outlined" onClick={prevPage} disabled={pageNumber <= 1}>
-            Prev
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={nextPage}
-            disabled={!numPages || pageNumber >= numPages}
-          >
-            Next
-          </Button>
-        </div>
-      </div>
-      <div
-        ref={containerRef}
-        style={{
-          border: "1px solid #eee",
-          borderRadius: 8,
-          padding: 12,
-          background: "#fafafa",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <Document
-          file={file}
-          onLoadSuccess={onDocumentLoadSuccess}
-          loading={<div>Loading PDF…</div>}
-        >
-          <Page
-            pageNumber={pageNumber}
-            width={pageWidth}
-            renderTextLayer={false}
-            renderAnnotationLayer={false}
-          />
-        </Document>
-      </div>
-      <div style={{ marginTop: 8, color: "#666" }}>
-        Page {pageNumber}
-        {numPages ? ` / ${numPages}` : ""}
-      </div>
-    </div>
-  );
-};
+import Script from "next/script";
 
 const StaffTraining = () => {
   return (
@@ -131,13 +6,16 @@ const StaffTraining = () => {
       <h2 className="mb-1" style={{ color: "#ef5350", fontWeight: 600 }}>
         Staff Training
       </h2>
-      <div
-        style={{ width: "100%", display: "flex", gap: "10px", flexDirection: "column" }}
-      >
-        {pdfs.map((item) => (
-          <PDFViewer key={item.id} file={item.url} title={item.title} />
-        ))}
+      <div style={{ width: "100%", height: "80vh" }}>
+        <iframe
+          className="clickup-embed clickup-dynamic-height"
+          src="https://doc.clickup.com/8469349/d/h/82ev5-21071/b442ccf5fa284fb"
+          width="100%"
+          height="100%"
+          style={{ background: "transparent", border: "1px solid #ccc" }}
+        />
       </div>
+      <Script async src="https://app-cdn.clickup.com/assets/js/forms-embed/v1.js" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the legacy download button layouts with embedded ClickUp documents for policies, quick start, staff training, and sales materials pages
- load the ClickUp embed script on each page to ensure the dynamic iframe resizes correctly

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_b_68dccf6523b4832a9d635b47eb31e36a