### PR TITLE
Update sidebar playbook label

### DIFF
--- a/components/components/common/drawer.js
+++ b/components/components/common/drawer.js
@@ -138,7 +138,7 @@ const Sidebar = ({ variant = "permanent", drawerOpen, onClick }) => {
             }}
           >
             <ListItemText
-              primary={"Office Playbook"}
+              primary={"Playbook"}
               primaryTypographyProps={{
                 fontWeight: "normal",
                 color: "inherit",


### PR DESCRIPTION
## Summary
- rename the sidebar playbook label to drop the "Office" prefix

## Testing
- yarn dev (fails: workspace missing from lockfile)

------
https://chatgpt.com/codex/tasks/task_b_68dc4a6b1384832a83bfaa2e9efbf731