### PR TITLE
Adjust dashboard embed container height

### DIFF
--- a/components/components/homepageContent/Dashboard.js
+++ b/components/components/homepageContent/Dashboard.js
@@ -64,7 +64,7 @@ const Dashboard = () => {
       >
         {"New Offer -> Welcome to byteSense!"}
       </div>
-      <div style={{ width: "100%", minHeight: "60vh" }}>
+      <div style={{ width: "100%", height: "80vh" }}>
         <iframe
           className="clickup-embed clickup-dynamic-height"
           src="https://doc.clickup.com/8469349/d/h/82ev5-21151/1bface5cf24acb3"


### PR DESCRIPTION
## Summary
- align the dashboard ClickUp embed container height with the other pages by switching to a fixed viewport height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2f1d83c0c832abf73ee937e95e3f9